### PR TITLE
Fixes #36 by changing shebang

### DIFF
--- a/desk-changer@eric.gach.gmail.com/desk-changer-daemon.py
+++ b/desk-changer@eric.gach.gmail.com/desk-changer-daemon.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python3
 
 import os
 import os.path


### PR DESCRIPTION
This file now runs with /usr/bin/python3 by default rather than the environment python, which could cause a Gio.DbusError (for example, if the environment python was python2 or anaconda).